### PR TITLE
Use a dock widget instead of message log

### DIFF
--- a/QgisNetworkLogger.py
+++ b/QgisNetworkLogger.py
@@ -1,11 +1,24 @@
 # -*- coding: utf-8 -*-
 # Import the PyQt and QGIS libraries
-from qgis.PyQt.QtCore import *
-from qgis.PyQt.QtGui import *
-from qgis.PyQt.QtWidgets import *
-from qgis.core import *
-
+from qgis.core import (
+    QgsNetworkAccessManager,
+    QgsNetworkReplyContent,
+    QgsNetworkRequestParameters,
+    QgsMessageLog,
+    Qgis
+)
+from qgis.PyQt.QtCore import (
+    QCoreApplication,
+    Qt
+)
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import (
+    QAction,
+    QMessageBox
+)
 from qgis.PyQt.QtNetwork import QNetworkRequest, QNetworkReply
+
+from .log_dock_widget import NetworkActivityDock
 
 import os
 
@@ -20,6 +33,7 @@ class QgisNetworkLogger:
         # TODO put in gui/settings
         self.show_request_headers = True
         self.show_response_headers = True
+        self.dock = None
 
     def initGui(self):
         # Create action that will start plugina
@@ -28,28 +42,21 @@ class QgisNetworkLogger:
         self.action.triggered.connect(self.show_dialog)
         # Add menu item
         self.iface.addPluginToMenu('QGIS Network Logger', self.action)
+        self.dock = NetworkActivityDock()
+        self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dock)
         self.log_it()
 
     def unload(self):
         # Remove the plugin menu item
         self.iface.removePluginMenu('QGIS Network Logger',self.action)
-        # cannot find a way to check IF we are listening to a signal, so dirty way: just do try catch
-        try:
-            self.nam.requestAboutToBeCreated[QgsNetworkRequestParameters].disconnect(self.request_about_to_be_created)
-        except:
-            self.show("Unloading plugin, disconnecting 'requestAboutToBeCreated'-signal failed, probably not connected.")
-        try:
-            self.nam.finished[QgsNetworkReplyContent].disconnect(self.request_finished)
-        except:
-            self.show("Unloading plugin, disconnecting 'finished'-signal failed, probably not connected.")
+
         try:
             self.nam.requestTimedOut[QgsNetworkRequestParameters].disconnect(self.request_timed_out)
         except:
             self.show("Unloading plugin, disconnecting 'requestTimedOut'-signal failed, probably not connected.")
+        self.iface.removeDockWidget(self.dock)
 
     def log_it(self):
-        self.nam.requestAboutToBeCreated[QgsNetworkRequestParameters].connect(self.request_about_to_be_created)
-        self.nam.finished[QgsNetworkReplyContent].connect(self.request_finished)
         self.nam.requestTimedOut[QgsNetworkRequestParameters].connect(self.request_timed_out)
 
     def show_dialog(self):
@@ -63,44 +70,7 @@ class QgisNetworkLogger:
         return
 
     def show(self, msg):
-        QgsMessageLog.logMessage(msg, "QGIS Network Logger...", Qgis.MessageLevel.Info)
-
-    # request_params = QgsNetworkRequestParameters with QNetworkRequest
-    def request_about_to_be_created(self, request_params):
-        operation = request_params.operation()
-        op = "Custom"
-        if operation == 1: op = "HEAD"
-        elif operation == 2: op = "GET"
-        elif operation == 3: op = "PUT"
-        elif operation == 4: op = "POST"
-        elif operation == 5: op = "DELETE"
-        url = request_params.request().url().url()
-        thread_id = request_params.originatingThreadId()
-        request_id = request_params.requestId()
-        headers = ''
-        if self.show_request_headers:
-            for header in request_params.request().rawHeaderList():
-                headers+='<br/>'+header.data().decode('utf-8')+' =  '+request_params.request().rawHeader(header).data().decode('utf-8')
-        self.show('Request {} in thread {} {} <a href="{}">{}</a> <span style="color:gray;">{}</span>'.format(request_id, thread_id, op, url, url, headers))
-
-    # reply is a QgsNetworkReplyContent
-    def request_finished(self, reply):
-        request = reply.request()
-        request_id = reply.requestId()
-        status =  reply.attribute(QNetworkRequest.HttpStatusCodeAttribute) # QNetworkRequest::HttpStatusCodeAttribute = 0
-        headers = ''
-        if self.show_response_headers:
-            for header in reply.rawHeaderList():
-                headers+='<br/>'+header.data().decode('utf-8')+' =  '+reply.rawHeader(header).data().decode('utf-8')
-        error = ''
-        # Note: When the HTTP protocol returns a redirect no error will be reported. You can check if there is a redirect with the QNetworkRequest::RedirectionTargetAttribute attribute.
-        # TODO check for QNetworkRequest::RedirectionTargetAttribute ?
-        if reply.error():   # QNetworkReply::NoError = 0 == False
-            # http://doc.qt.io/qt-5/qnetworkreply.html#NetworkError-enum
-            link = 'http://doc.qt.io/qt-5/qnetworkreply.html#NetworkError-enum'
-            error = ' with error: {} ( see <a href="{}">{}</a> )'.format(reply.error(), link, 'Qt Network Error codes')
-        self.show('Finished {} with status {} {} <span style="color:gray;">{}</span>'.format(request_id, status, error, headers))
-
+        QgsMessageLog.logMessage(msg, "QGIS Network Logger...", Qgis.Info)
 
     # request_params = QgsNetworkRequestParameters
     def request_timed_out(self, request_params):

--- a/log_dock_widget.py
+++ b/log_dock_widget.py
@@ -1,0 +1,302 @@
+# -----------------------------------------------------------
+# Copyright (C) 2015 Martin Dobias
+# -----------------------------------------------------------
+# Licensed under the terms of GNU GPL 2
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# ---------------------------------------------------------------------
+
+from qgis.PyQt.QtCore import (
+    QAbstractItemModel,
+    QModelIndex,
+    Qt
+)
+from qgis.PyQt.QtWidgets import (
+    QTreeView,
+    QLabel
+)
+from qgis.PyQt.QtNetwork import (
+    QNetworkAccessManager,
+    QNetworkRequest
+)
+from qgis.gui import QgsDockWidget
+from qgis.core import (
+    QgsNetworkAccessManager,
+    QgsNetworkReplyContent,
+    QgsNetworkRequestParameters
+)
+
+
+class ActivityTreeItem(object):
+
+    def __init__(self, name, parent=None):
+        self.name = name
+        self.populated_children = False
+
+        self.parent = parent
+        self.children = []
+        if parent:
+            parent.children.append(self)
+
+    def span(self):
+        return False
+
+    def text(self, column):
+        return ''
+
+    def tooltip(self, column):
+        return self.text(column)
+
+    def createWidget(self):
+        return None
+
+
+class RootItem(ActivityTreeItem):
+    def __init__(self, parent=None):
+        super().__init__('', parent)
+
+
+class RequestParentItem(ActivityTreeItem):
+    def __init__(self, request, parent=None):
+        super().__init__('', parent)
+        self.url = request.request().url()
+        RequestItem(request, self)
+
+    def span(self):
+        return True
+
+    def text(self, column):
+        return None
+
+    def tooltip(self, column):
+        return self.url.url()
+
+    def set_reply(self, reply):
+        # todo - emit row added signals?
+        ReplyItem(reply, self)
+
+    def createWidget(self):
+        label = QLabel('<a href="{}">{}</a>'.format(self.url.url(), self.url.url()))
+        label.setOpenExternalLinks(True)
+        return label
+
+
+class RequestItem(ActivityTreeItem):
+    def __init__(self, request, parent=None):
+        super().__init__('', parent)
+
+        self.url = request.request().url()
+
+        operation = request.operation()
+        op = "Custom"
+        if operation == QNetworkAccessManager.HeadOperation:
+            op = "HEAD"
+        elif operation == QNetworkAccessManager.GetOperation:
+            op = "GET"
+        elif operation == QNetworkAccessManager.PutOperation:
+            op = "PUT"
+        elif operation == QNetworkAccessManager.PostOperation:
+            op = "POST"
+        elif operation == QNetworkAccessManager.DeleteOperation:
+            op = "DELETE"
+
+        RequestDetailsItem('Operation', op, self)
+        RequestDetailsItem('Thread', request.originatingThreadId(), self)
+        RequestHeadersItem(request, self)
+
+    def span(self):
+        return True
+
+    def text(self, column):
+        return 'Request' if column == 0 else None
+
+
+class RequestDetailsItem(ActivityTreeItem):
+    def __init__(self, description, value, parent=None):
+        super().__init__('', parent)
+
+        self.description = description
+        self.value = value
+
+    def text(self, column):
+        if column == 0:
+            return self.description
+        else:
+            return self.value
+
+
+class RequestHeadersItem(ActivityTreeItem):
+    def __init__(self, request, parent=None):
+        super().__init__('Headers', parent)
+
+        for header in request.request().rawHeaderList():
+            RequestDetailsItem(header.data().decode('utf-8'),
+                               request.request().rawHeader(header).data().decode('utf-8'), self)
+
+    def text(self, column):
+        if column == 0:
+            return 'Headers'
+        else:
+            return None
+
+    def span(self):
+        return True
+
+
+class ReplyItem(ActivityTreeItem):
+    def __init__(self, reply, parent=None):
+        super().__init__('', parent)
+        ReplyDetailsItem('Status', reply.attribute(QNetworkRequest.HttpStatusCodeAttribute), self)
+        ReplyHeadersItem(reply, self)
+
+    def span(self):
+        return True
+
+    def text(self, column):
+        return 'Reply' if column == 0 else None
+
+
+class ReplyHeadersItem(ActivityTreeItem):
+    def __init__(self, reply, parent=None):
+        super().__init__('Headers', parent)
+
+        for header in reply.rawHeaderList():
+            ReplyDetailsItem(header.data().decode('utf-8'),
+                             reply.rawHeader(header).data().decode('utf-8'), self)
+
+    def text(self, column):
+        if column == 0:
+            return 'Headers'
+        else:
+            return None
+
+    def span(self):
+        return True
+
+
+class ReplyDetailsItem(ActivityTreeItem):
+    def __init__(self, description, value, parent=None):
+        super().__init__('', parent)
+
+        self.description = description
+        self.value = value
+
+    def text(self, column):
+        if column == 0:
+            return self.description
+        else:
+            return self.value
+
+
+class NetworkActivityModel(QAbstractItemModel):
+    def __init__(self, root_item, parent=None):
+        super().__init__(parent)
+        self.root_item = root_item
+
+        nam = QgsNetworkAccessManager.instance()
+
+        nam.requestAboutToBeCreated[QgsNetworkRequestParameters].connect(self.request_about_to_be_created)
+        nam.finished[QgsNetworkReplyContent].connect(self.request_finished)
+        nam.requestTimedOut[QgsNetworkRequestParameters].connect(self.request_timed_out)
+
+        self.requests = {}
+
+    def request_about_to_be_created(self, request_params):
+        self.beginInsertRows(QModelIndex(), len(self.root_item.children), len(self.root_item.children))
+        self.requests[request_params.requestId()] = RequestParentItem(request_params, self.root_item)
+        self.endInsertRows()
+
+    def request_finished(self, reply):
+        request_item = self.requests[reply.requestId()]
+        request_item.set_reply(reply)
+
+    def request_timed_out(self, request_params):
+        # TODO
+        pass
+        # url = request_params.request().url().url()
+        # thread_id = request_params.originatingThreadId()
+        # request_id = request_params.requestId()
+        ##self.show('Timeout or abort: <a href="{}">{}</a>'.format(url, url))
+        # self.show('Timeout or abort {} in thread {}'.format(request_id, thread_id))
+
+    def columnCount(self, parent):
+        return 2
+
+    def rowCount(self, parent):
+        if parent.column() > 0:
+            return 0
+
+        parent_item = self.root_item if not parent.isValid() else parent.internalPointer()
+        return len(parent_item.children)
+
+    def data(self, index, role):
+        if not index.isValid():
+            return
+
+        item = index.internalPointer()
+        if role == Qt.DisplayRole:
+            return item.text(index.column())
+        elif role == Qt.ToolTipRole:
+            return item.tooltip(index.column())
+
+    def flags(self, index):
+        if not index.isValid():
+            return 0
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable
+
+    def index(self, row, column, parent):
+        if not self.hasIndex(row, column, parent):
+            return QModelIndex()
+
+        parent_item = self.root_item if not parent.isValid() else parent.internalPointer()
+        child_item = parent_item.children[row]
+        return self.createIndex(row, column, child_item)
+
+    def parent(self, index):
+        if not index.isValid():
+            return QModelIndex()
+
+        parent_item = index.internalPointer().parent
+        if parent_item.parent is None:
+            return QModelIndex()
+
+        parent_index_in_grandparent = parent_item.parent.children.index(parent_item)
+        return self.createIndex(parent_index_in_grandparent, 0, parent_item)
+
+    def headerData(self, section, orientation, role):
+        if section == 0 and orientation == Qt.Horizontal and role == Qt.DisplayRole:
+            return "Requests"
+
+
+class ActivityView(QTreeView):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.model = NetworkActivityModel(RootItem(), self)
+        self.setModel(self.model)
+
+        self.model.rowsInserted.connect(self.rows_inserted)
+
+    def rows_inserted(self, parent, first, last):
+        # silly qt API - this shouldn't be so hard!
+        for r in range(first, last + 1):
+            this_index = self.model.index(r, 0, parent)
+            if this_index.internalPointer().span():
+                self.setFirstColumnSpanned(r, parent, True)
+            for i in range(self.model.rowCount(this_index)):
+                self.rows_inserted(this_index, i, i)
+
+            w = this_index.internalPointer().createWidget()
+            if w:
+                self.setIndexWidget(this_index, w)
+
+
+class NetworkActivityDock(QgsDockWidget):
+
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle('Network Activity')
+        self.view = ActivityView()
+        self.setWidget(self.view)

--- a/log_dock_widget.py
+++ b/log_dock_widget.py
@@ -89,9 +89,9 @@ class RequestParentItem(ActivityTreeItem):
     def text(self, column):
         if column == 0:
             return self.url.url()
+        return ''
 
     def set_reply(self, reply):
-        # todo - emit row added signals?
         if reply.error() != QNetworkReply.NoError:
             self.status = ERROR
         else:
@@ -126,7 +126,7 @@ class RequestItem(ActivityTreeItem):
         return True
 
     def text(self, column):
-        return 'Request' if column == 0 else None
+        return 'Request' if column == 0 else ''
 
 
 class RequestDetailsItem(ActivityTreeItem):
@@ -155,7 +155,7 @@ class RequestHeadersItem(ActivityTreeItem):
         if column == 0:
             return 'Headers'
         else:
-            return None
+            return ''
 
     def span(self):
         return True
@@ -175,7 +175,7 @@ class ReplyItem(ActivityTreeItem):
         return True
 
     def text(self, column):
-        return 'Reply' if column == 0 else None
+        return 'Reply' if column == 0 else ''
 
 
 class ReplyHeadersItem(ActivityTreeItem):
@@ -190,7 +190,7 @@ class ReplyHeadersItem(ActivityTreeItem):
         if column == 0:
             return 'Headers'
         else:
-            return None
+            return ''
 
     def span(self):
         return True
@@ -274,9 +274,14 @@ class NetworkActivityModel(QAbstractItemModel):
         if not reply.requestId() in self.requests_items:
             return
 
+        request_index = self.request_indices[reply.requestId()]
         request_item = self.requests_items[reply.requestId()]
+
+        self.beginInsertRows(request_index, len(request_item.children), len(request_item.children))
         request_item.set_reply(reply)
-        self.dataChanged.emit(self.request_indices[reply.requestId()],self.request_indices[reply.requestId()])
+        self.endInsertRows()
+
+        self.dataChanged.emit(request_index,request_index)
 
     def request_timed_out(self, request_params):
         # TODO


### PR DESCRIPTION
This PR swaps the logging from the standard QGIS message log to a custom dock widget with a tree view

This allows the replies to be directly linked to their original requests, easing debugging:

![peek 2019-01-24 17-07](https://user-images.githubusercontent.com/1829991/51660820-a3afc000-1ffa-11e9-9f09-28cdef1e9cce.gif)

It's not feature complete -- e.g.

[ ] timeouts aren't logged yet.
[ ] should have a "clear" button
[ ] add filtering by url